### PR TITLE
Stm32 support

### DIFF
--- a/NmraDcc.cpp
+++ b/NmraDcc.cpp
@@ -155,21 +155,20 @@
         #define MODE_TP4 pinMode( PB15,OUTPUT )   // TP4 = PB15
         #define SET_TP4  gpio_write_bit( GPIOB,15, HIGH );
         #define CLR_TP4  gpio_write_bit( GPIOB,15, LOW );
+    #elif defined(ESP8266)
+        #define MODE_TP1 pinMode( D5,OUTPUT ) ; // GPIO 14
+        #define SET_TP1  GPOS = (1 << D5);
+        #define CLR_TP1  GPOC = (1 << D5);
+        #define MODE_TP2 pinMode( D6,OUTPUT ) ; // GPIO 12
+        #define SET_TP2  GPOS = (1 << D6);
+        #define CLR_TP2  GPOC = (1 << D6);
+        #define MODE_TP3 pinMode( D7,OUTPUT ) ; // GPIO 13
+        #define SET_TP3  GPOS = (1 << D7);
+        #define CLR_TP3  GPOC = (1 << D7);
+        #define MODE_TP4 pinMode( D7,OUTPUT ); // GPIO 15
+        #define SET_TP4  GPOC = (1 << D8);
+        #define CLR_TP4  GPOC = (1 << D8);
         
-    #elif defined (__SAM3X8E__)
-        // Arduino Due
-        #define MODE_TP1 pinMode( A1,OUTPUT )   // A1= PA24
-        #define SET_TP1  REG_PIOA_SODR = (1<<24)
-        #define CLR_TP1  REG_PIOA_CODR = (1<<24)
-        #define MODE_TP2 pinMode( A2,OUTPUT )   // A2= PA23
-        #define SET_TP2  REG_PIOA_SODR = (1<<23)
-        #define CLR_TP2  REG_PIOA_CODR = (1<<23)
-        #define MODE_TP3 pinMode( A3,OUTPUT )   // A3 = PA22
-        #define SET_TP3  REG_PIOA_SODR = (1<<22)
-        #define CLR_TP3  REG_PIOA_CODR = (1<<22)
-        #define MODE_TP4 pinMode( A4,OUTPUT )   // A4 = PA6
-        #define SET_TP4  REG_PIOA_SODR = (1<<6)
-        #define CLR_TP4  REG_PIOA_CODR = (1<<6)
         
     //#elif defined(__AVR_ATmega128__) ||defined(__AVR_ATmega1281__)||defined(__AVR_ATmega2561__)
     #else
@@ -497,6 +496,7 @@ void writeEEPROM( unsigned int CV, uint8_t Value ) {
     EEPROM.write(CV, Value) ;
   #if defined(ESP8266)
     EEPROM.commit();
+  #endif
 }
 
 bool readyEEPROM() {

--- a/NmraDcc.cpp
+++ b/NmraDcc.cpp
@@ -21,7 +21,8 @@
 //                       and new signature of notifyDccSpeed and notifyDccFunc
 //            2015-12-16 Version without use of Timer0 by Franz-Peter Müller
 //            2016-07-16 handle glitches on DCC line
-//						2016-08-20 added ESP8266 support by Sven (littleyoda) 
+//			  2016-08-20 added ESP8266 support by Sven (littleyoda) 
+//			  2017-01-19 added STM32F1 support by Franz-Peter
 //
 //------------------------------------------------------------------------
 //
@@ -31,13 +32,7 @@
 //------------------------------------------------------------------------
 
 #include "NmraDcc.h"
-/*
-#if defined(ESP8266)
-  #include <EEPROM.h>
-#else
-#include <avr/eeprom.h>
-#endif
-*/
+
 //------------------------------------------------------------------------
 // DCC Receive Routine
 //
@@ -495,30 +490,17 @@ void ackCV(void)
 }
 
 uint8_t readEEPROM( unsigned int CV ) {
-  //#if defined(ESP8266)
     return EEPROM.read(CV) ;
-  //#else
-  //  return eeprom_read_byte( (uint8_t*) CV );
-  //#endif
 }
 
 void writeEEPROM( unsigned int CV, uint8_t Value ) {
-  //#if defined(ESP8266)
     EEPROM.write(CV, Value) ;
   #if defined(ESP8266)
     EEPROM.commit();
- /* #else
-    eeprom_write_byte( (uint8_t*) CV, Value ) ;
-	*/
-  #endif
 }
 
 bool readyEEPROM() {
-  //#if defined(ESP8266)
     return true;
-  //#else
-  //  return eeprom_is_ready();
-  //#endif
 }
 
 
@@ -1037,7 +1019,12 @@ NmraDcc::NmraDcc()
 
 void NmraDcc::pin( uint8_t ExtIntNum, uint8_t ExtIntPinNum, uint8_t EnablePullup)
 {
+#if defined ( __STM32F1__ )
+  // with STM32F1 the interuptnumber is equal the pin number
+  DccProcState.ExtIntNum = ExtIntPinNum;
+#else
   DccProcState.ExtIntNum = ExtIntNum;
+#endif
   DccProcState.ExtIntPinNum = ExtIntPinNum;
 	
   pinMode( ExtIntPinNum, INPUT );

--- a/NmraDcc.cpp
+++ b/NmraDcc.cpp
@@ -86,7 +86,7 @@
 
 
 // Debug-Ports
-#define debug     // Testpulse for logic analyser
+//#define debug     // Testpulse for logic analyser
 #ifdef debug 
     #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
         #define MODE_TP1 DDRF |= (1<<2) //pinA2

--- a/NmraDcc.h
+++ b/NmraDcc.h
@@ -99,7 +99,7 @@ typedef struct
 #define MAXCV	(EEPROM_PAGE_SIZE/4 - 1)	// number of storage places (CV address could be larger
 											// because STM32 uses virtual adresses)
 #else
-#define MAXCV                                 E2END     // the upper limit of the CV value currently defined to max memory.
+#define MAXCV    E2END     					// the upper limit of the CV value currently defined to max memory.
 #endif
 
 typedef enum {

--- a/NmraDcc.h
+++ b/NmraDcc.h
@@ -42,6 +42,8 @@
 #include "WProgram.h"
 #endif
 
+#include "EEPROM.h"
+
 #ifndef NMRADCC_IS_IN
 #define NMRADCC_IS_IN
 
@@ -93,6 +95,9 @@ typedef struct
 #if defined(ESP8266)
 #include <spi_flash.h>
 #define MAXCV     SPI_FLASH_SEC_SIZE
+#elif defined( __STM32F1__)
+#define MAXCV	(EEPROM_PAGE_SIZE/4 - 1)	// number of storage places (CV address could be larger
+											// because STM32 uses virtual adresses)
 #else
 #define MAXCV                                 E2END     // the upper limit of the CV value currently defined to max memory.
 #endif

--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Enables NMRA DCC Communication
 paragraph=This library allows you to interface to a NMRA DCC track signal and receive DCC commands. The library currently supports the AVR ATTiny84/85 & ATMega88/168/328/32u4 and Teensy 3.x using the INT0/1 Hardware Interrupt and micros() ONLY and no longer uses Timer0 Compare Match B, which makes it much more portable to other platforms
 category=Communication
 url=http://mrrwa.org/dcc-decoder-interface/
-architectures=avr,esp8266
+architectures=avr,esp8266,stm32f103

--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Enables NMRA DCC Communication
 paragraph=This library allows you to interface to a NMRA DCC track signal and receive DCC commands. The library currently supports the AVR ATTiny84/85 & ATMega88/168/328/32u4 and Teensy 3.x using the INT0/1 Hardware Interrupt and micros() ONLY and no longer uses Timer0 Compare Match B, which makes it much more portable to other platforms
 category=Communication
 url=http://mrrwa.org/dcc-decoder-interface/
-architectures=avr,esp8266,stm32f103
+architectures=avr,esp8266,STM32F1


### PR DESCRIPTION
Hi Alex,
I added support for the STM32F1 processors to the Dcc Library. 
Just like the ESP8266 the STM32 uses flash vor emulating EEPROM. And only the arduino EEPROM calls are supported. Therefore I switched completely to these calls. Now only the two special EEPROM functions for ESP8266 are processor dependent.
Besides that some adjustments with  attaching interrupts had been necessary.

Regards
Franz-Peter