### PR TITLE
With eeprom_is_ready() for AVR-processors

### DIFF
--- a/NmraDcc.cpp
+++ b/NmraDcc.cpp
@@ -2,7 +2,7 @@
 //
 // Model Railroading with Arduino - NmraDcc.cpp 
 //
-// Copyright (c) 2008 - 2105 Alex Shepherd
+// Copyright (c) 2008 - 2017 Alex Shepherd
 //
 // This source file is subject of the GNU general public license 2,
 // that is available at the world-wide-web at

--- a/NmraDcc.cpp
+++ b/NmraDcc.cpp
@@ -32,6 +32,9 @@
 //------------------------------------------------------------------------
 
 #include "NmraDcc.h"
+#ifdef __AVR_MEGA__
+#include <avr/eeprom.h>
+#endif
 
 //------------------------------------------------------------------------
 // DCC Receive Routine
@@ -288,9 +291,9 @@ void ExternalInterruptHandler(void)
     }
     DccBitVal = ( bitMicros < bitMax );
     lastMicros = actMicros;
-    //#ifdef debug
+    #ifdef debug
     if(DccBitVal) {SET_TP2;} else {CLR_TP2;};
-    //#endif
+    #endif
     DCC_IrqRunning = true;
     interrupts();  // time critical is only the micros() command,so allow nested irq's
 #ifdef DCC_DEBUG
@@ -500,7 +503,11 @@ void writeEEPROM( unsigned int CV, uint8_t Value ) {
 }
 
 bool readyEEPROM() {
-    return true;
+    #ifdef __AVR_MEGA__
+        return eeprom_is_ready();
+    #else
+        return true;
+    #endif
 }
 
 


### PR DESCRIPTION
Hi Alex,
this is my version with the reactivation of the eeprom_is_ready() function for the AVR-platform.
I tested on AVR, ESP and STM32
