### PR TITLE
Addition of notifyServceMode call to allow decoders to turn off high current outputs

### DIFF
--- a/NmraDcc.cpp
+++ b/NmraDcc.cpp
@@ -881,6 +881,10 @@ void resetServiceModeTimer(uint8_t inServiceMode)
   DccProcState.inServiceMode = inServiceMode ;
   
   DccProcState.LastServiceModeMillis = inServiceMode ? millis() : 0 ;
+  if (notifyServiceMode && inServiceMode != DccProcState.inServiceMode)
+  {
+    notifyServiceMode(inServiceMode);
+  }
 }
 
 void clearDccProcState(uint8_t inServiceMode)

--- a/NmraDcc.cpp
+++ b/NmraDcc.cpp
@@ -877,6 +877,10 @@ void processServiceModeOperation( DCC_MSG * pDccMsg )
 #endif
 void resetServiceModeTimer(uint8_t inServiceMode)
 {
+  if (notifyServiceMode && inServiceMode != DccProcState.inServiceMode)
+  {
+    notifyServiceMode(inServiceMode);
+  }
   // Set the Service Mode
   DccProcState.inServiceMode = inServiceMode ;
   

--- a/NmraDcc.h
+++ b/NmraDcc.h
@@ -251,6 +251,7 @@ extern void    notifyCVChange( uint16_t CV, uint8_t Value) __attribute__ ((weak)
 extern void    notifyCVResetFactoryDefault(void) __attribute__ ((weak));
 
 extern void    notifyCVAck(void) __attribute__ ((weak));
+extern void    notifyServiceMode(bool) __attribute__ ((weak));
 
 #if defined (__cplusplus)
 }


### PR DESCRIPTION
When a decoder is powered by the DCC bus it must keep the current draw to below 500mA when in service mode programming. This call allows the decoder to turn off the high current draw outputs when in service mode.