### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,58 +6,58 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-DCC_MSG																	KEYWORD1
-NmraDcc																	KEYWORD1
+DCC_MSG	KEYWORD1
+NmraDcc	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-NmraDcc																KEYWORD2
-pin																	KEYWORD2
-init																KEYWORD2
-process																KEYWORD2
-getCV																KEYWORD2
-setCV																KEYWORD2
-isSetCVReady														KEYWORD2
-notifyDccReset														KEYWORD2
-notifyDccIdle														KEYWORD2
-notifyDccSpeed														KEYWORD2
-notifyDccSpeedRaw													KEYWORD2	
-notifyDccFunc														KEYWORD2
-notifyDccAccTurnoutBoard											KEYWORD2
-notifyDccAccTurnoutOutput											KEYWORD2
-notifyDccAccBoardAddrSet											KEYWORD2
-notifyDccAccOutputAddrSet											KEYWORD2
-notifyDccSigOutputState												KEYWORD2
-notifyDccMsg														KEYWORD2
-notifyCVValid														KEYWORD2
-notifyCVRead														KEYWORD2
-notifyCVWrite														KEYWORD2
-notifyIsSetCVReady													KEYWORD2
-notifyCVChange														KEYWORD2
-notifyCVAck															KEYWORD2
-notifyCVResetFactoryDefault											KEYWORD2
+NmraDcc	KEYWORD2
+pin	KEYWORD2
+init	KEYWORD2
+process	KEYWORD2
+getCV	KEYWORD2
+setCV	KEYWORD2
+isSetCVReady	KEYWORD2
+notifyDccReset	KEYWORD2
+notifyDccIdle	KEYWORD2
+notifyDccSpeed	KEYWORD2
+notifyDccSpeedRaw	KEYWORD2
+notifyDccFunc	KEYWORD2
+notifyDccAccTurnoutBoard	KEYWORD2
+notifyDccAccTurnoutOutput	KEYWORD2
+notifyDccAccBoardAddrSet	KEYWORD2
+notifyDccAccOutputAddrSet	KEYWORD2
+notifyDccSigOutputState	KEYWORD2
+notifyDccMsg	KEYWORD2
+notifyCVValid	KEYWORD2
+notifyCVRead	KEYWORD2
+notifyCVWrite	KEYWORD2
+notifyIsSetCVReady	KEYWORD2
+notifyCVChange	KEYWORD2
+notifyCVAck	KEYWORD2
+notifyCVResetFactoryDefault	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 
-MAN_ID_JMRI															LITERAL1
-MAN_ID_DIY															LITERAL1
-MAN_ID_SILICON_RAILWAY												LITERAL1
-FLAGS_MY_ADDRESS_ONLY												LITERAL1
-FLAGS_OUTPUT_ADDRESS_MODE											LITERAL1
-FLAGS_DCC_ACCESSORY_DECODER											LITERAL1
+MAN_ID_JMRI	LITERAL1
+MAN_ID_DIY	LITERAL1
+MAN_ID_SILICON_RAILWAY	LITERAL1
+FLAGS_MY_ADDRESS_ONLY	LITERAL1
+FLAGS_OUTPUT_ADDRESS_MODE	LITERAL1
+FLAGS_DCC_ACCESSORY_DECODER	LITERAL1
 
-CV_ACCESSORY_DECODER_ADDRESS_LSB									LITERAL1
-CV_ACCESSORY_DECODER_ADDRESS_MSB									LITERAL1
+CV_ACCESSORY_DECODER_ADDRESS_LSB	LITERAL1
+CV_ACCESSORY_DECODER_ADDRESS_MSB	LITERAL1
 
-CV_MULTIFUNCTION_PRIMARY_ADDRESS									LITERAL1
-CV_MULTIFUNCTION_EXTENDED_ADDRESS_MSB								LITERAL1
-CV_MULTIFUNCTION_EXTENDED_ADDRESS_LSB								LITERAL1
+CV_MULTIFUNCTION_PRIMARY_ADDRESS	LITERAL1
+CV_MULTIFUNCTION_EXTENDED_ADDRESS_MSB	LITERAL1
+CV_MULTIFUNCTION_EXTENDED_ADDRESS_LSB	LITERAL1
 
-CV_VERSION_ID														LITERAL1
-CV_MANUFACTURER_ID													LITERAL1
-CV_29_CONFIG														LITERAL1
-CV_OPS_MODE_ADDRESS_LSB												LITERAL1
+CV_VERSION_ID	LITERAL1
+CV_MANUFACTURER_ID	LITERAL1
+CV_29_CONFIG	LITERAL1
+CV_OPS_MODE_ADDRESS_LSB	LITERAL1
 
 #######################################


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords