### PR TITLE
Esp32 iram attr

### DIFF
--- a/NmraDcc.cpp
+++ b/NmraDcc.cpp
@@ -310,6 +310,8 @@ DCC_PROCESSOR_STATE DccProcState ;
 portMUX_TYPE mux = portMUX_INITIALIZER_UNLOCKED;
 
 void IRAM_ATTR ExternalInterruptHandler(void)
+#elif defined(ESP8266)
+void ICACHE_RAM_ATTR ExternalInterruptHandler(void)
 #else
 void ExternalInterruptHandler(void)
 #endif
@@ -340,9 +342,9 @@ void ExternalInterruptHandler(void)
 // Bit evaluation without Timer 0 ------------------------------
     uint8_t DccBitVal;
     static int8_t  bit1, bit2 ;
-    static word  lastMicros;
+    static unsigned long  lastMicros = 0;
     static byte halfBit, DCC_IrqRunning;
-    unsigned int  actMicros, bitMicros;
+    unsigned long  actMicros, bitMicros;
     if ( DCC_IrqRunning ) {
         // nested DCC IRQ - obviously there are glitches
         // ignore this interrupt and increment glitchcounter

--- a/NmraDcc.h
+++ b/NmraDcc.h
@@ -49,7 +49,7 @@
 #ifndef NMRADCC_IS_IN
 #define NMRADCC_IS_IN
 
-#define NMRADCC_VERSION     200     // Version 2.0.0
+#define NMRADCC_VERSION     201     // Version 2.0.1
 
 #define MAX_DCC_MESSAGE_LEN 6    // including XOR-Byte
 

--- a/NmraDcc.h
+++ b/NmraDcc.h
@@ -53,6 +53,8 @@
 
 #define MAX_DCC_MESSAGE_LEN 6    // including XOR-Byte
 
+//#define ALLOW_NESTED_IRQ      // uncomment to enable nested IRQ's ( only for AVR! )
+
 typedef struct
 {
 	uint8_t	Size ;
@@ -105,6 +107,9 @@ typedef struct
 #elif defined( __STM32F1__)
 	#define MAXCV	(EEPROM_PAGE_SIZE/4 - 1)	// number of storage places (CV address could be larger
 											// because STM32 uses virtual adresses)
+    #undef ALLOW_NESTED_IRQ                 // This is done with NVIC on STM32
+    #define PRIO_DCC_IRQ    9
+    #define PRIO_SYSTIC     8               // MUST be higher priority than DCC Irq
 #else
 	#define MAXCV    E2END     					// the upper limit of the CV value currently defined to max memory.
 #endif


### PR DESCRIPTION
Hi Alex,
here are my proposals:

- I switched back to unsigned int for the micros values. This saves a little bit time in the ISR on AVR and is sufficent for our needs. On 32bit platforms as with ESP32 or ES8266 this is the same as unsigned long.
- Permitting nested interrupts is configurable now, where the default is not to permit nested Interrupts
- On the STM32F1 platform, the nested interrupt feature is done by the NVIC Interruptcontroller of the STM32. This is mandatory on this platform, because the micros() function does not always give correct values, if interrupts are blocked when it is called.