### PR TITLE
Fix comments in NmraDcc.h

### DIFF
--- a/NmraDcc.h
+++ b/NmraDcc.h
@@ -500,7 +500,7 @@ extern void    notifyDccFunc( uint16_t Addr, DCC_ADDR_TYPE AddrType, FN_GROUP Fu
 
 /*+
  *  notifyDccAccTurnoutBoard() Board oriented callback for a turnout accessory decoder.
- *                             Most useful when CV29_OUTPUT_ADDRESS_MODE is not set.
+ *                             Most useful when CV29_OUTPUT_ADDRESS_MODE is NOT set.
  *                             Decoders of this type have 4 paired turnout outputs per board.
  *                             OutputPower is 1 if the power is on, and 0 otherwise.
  *
@@ -521,7 +521,7 @@ extern void    notifyDccFunc( uint16_t Addr, DCC_ADDR_TYPE AddrType, FN_GROUP Fu
 extern void    notifyDccAccTurnoutBoard( uint16_t BoardAddr, uint8_t OutputPair, uint8_t Direction, uint8_t OutputPower ) __attribute__ ((weak));
 /*+
  *  notifyDccAccTurnoutOutput() Output oriented callback for a turnout accessory decoder.
- *                              Most useful when CV29_OUTPUT_ADDRESS_MODE is not set.
+ *                              Most useful when CV29_OUTPUT_ADDRESS_MODE IS set.
  *                              Decoders of this type have 4 paired turnout outputs per board.
  *                              OutputPower is 1 if the power is on, and 0 otherwise.
  *


### PR DESCRIPTION
Fix notifyDccAccTurnoutOutput() comments to show this is used when CV29_OUTPUT_ADDRESS_MODE IS set. Add emphasis to this and notifyDccAccTurnoutBoard() similar routine. Related to this Issue: https://github.com/mrrwa/NmraDcc/issues/52