### PR TITLE
Add example compilation to the project

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,40 @@
+on:
+- push
+- pull_request
+
+jobs:
+  build:
+    name: ${{ matrix.arduino-boards-fqbn }} - test compiling examples
+
+    runs-on: ubuntu-latest # I picked Ubuntu to use shell scripts.
+
+    strategy:
+      matrix:
+        # The matrix will produce one job for each configuration parameter of type `arduino-boards-fqbn`
+        # In the Arduino IDE, the fqbn is printed in the first line of the verbose output for compilation as parameter -fqbn=... for the "arduino-builder -dump-prefs" command
+        # You may add a suffix behind the fqbn with "|" to specify one board for e.g. different compile options like arduino:avr:uno|trace
+        #############################################################################################################
+        arduino-boards-fqbn:
+          - arduino:avr:uno
+
+      # Do not cancel all jobs / architectures if one job fails
+      fail-fast: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Checkout custom library
+        uses: actions/checkout@v3
+        with:
+          repository: chatelao/SoftwareServo
+          ref: main
+          path: CustomLibrary_SoftwareServo
+
+      - name: Compile all examples
+        uses: ArminJo/arduino-test-compile@v3
+        with:
+          required-libraries: AccelStepper,Servo,DFRobotDFPlayerMini,U8g2,EncButton,DFPlayerMini_Fast
+          platform-url: https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json
+          sketches-exclude: Dec_2Mot_4LED_Aud_8Ftn,Dec_2Mot_3LED_TrigAud,NmraDccMultiFunctionMotorDecoder-XIAO-Expansion,Fahrstuhl
+          arduino-board-fqbn: ${{ matrix.arduino-boards-fqbn }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -36,5 +36,5 @@ jobs:
         with:
           required-libraries: AccelStepper,Servo,DFRobotDFPlayerMini,U8g2,EncButton,DFPlayerMini_Fast
           platform-url: https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json
-          sketches-exclude: Dec_2Mot_4LED_Aud_8Ftn,Dec_2Mot_3LED_TrigAud,NmraDccMultiFunctionMotorDecoder-XIAO-Expansion,Fahrstuhl
+          sketches-exclude: Dec_2Mot_4LED_Aud_8Ftn,Dec_2Mot_3LED_TrigAud,NmraDccMultiFunctionMotorDecoder-XIAO-Expansion,Fahrstuhl,Loco_Test,Accessory_Test
           arduino-board-fqbn: ${{ matrix.arduino-boards-fqbn }}

--- a/examples/IDEC/IDEC4_3_ServosLEDsSounds3Plyr/IDEC4_3_ServosLEDsSounds3Plyr.ino
+++ b/examples/IDEC/IDEC4_3_ServosLEDsSounds3Plyr/IDEC4_3_ServosLEDsSounds3Plyr.ino
@@ -415,7 +415,7 @@ void setup()   //******************************************************
    // Master Decoder Disable
    MasterDecoderDisable = 0;
    if (digitalRead(MasterDecoderDisablePin)==LOW) MasterDecoderDisable = 1;
-   setVolumeOnChannel (starting_volume);
+   // setVolumeOnChannel (starting_volume);
 #ifdef DEBUG
     Serial.println("CV Dump:");
     for (i=30; i<41; i++) { Serial.print(i,DEC); Serial.print("\t"); }


### PR DESCRIPTION
Hi @kiwi64ajs and @gbglacier 

Here it is: a version using "SoftwareServo", currently from my repository "chatealo/SoftwareServo", but hopefully if @gbglacier agrees we should add it the "global" Arduino libraries, so even beginners could recompile the examples with ease.

What do you think about the idea to add a "SoftwareServo" to the "mrrwa" collection?

Some examples still failed to compile:

- IDEC4_3_ServosLEDsSounds3Plyr.ino (commented line "418")
- Dec_2Mot_4LED_Aud_8Ftn,Dec_2Mot_3LED_TrigAud,NmraDccMultiFunctionMotorDecoder-XIAO-Expansion,Fahrstuhl
- Loco_Test,Accessory_Test : I don't know how to add the "printf" to the Serial prints.

Regards, Oli