### PR TITLE
Support for some RCN-211 features (fastclock)

### DIFF
--- a/NmraDcc.h
+++ b/NmraDcc.h
@@ -752,6 +752,50 @@ extern void    notifyAdvancedCVAck (void) __attribute__ ( (weak));
  */
 extern void    notifyServiceMode (bool) __attribute__ ( (weak));
 
+
+/*+ 
+ * RCN-211
+ * Called when a fastclock message is received.
+ *
+ *  Inputs:
+ *      WeekDay - 0=Monday ... 6=Sunday.
+ *      Hour    - 0..23.
+ *      Minute  - 0..59.
+ *      Factor  - 0..63  0=clock stopped, 1 = real time, 2 = 2x real time, 3 = 3x real time etc.
+ *      Update  - true means clock has changed significantly.
+ *
+ *  Returns:
+ *      None
+ */
+extern void notifyFastClockTime( uint8_t  WeekDay, uint8_t Hour, uint8_t Minute, uint8_t Factor, bool Update) __attribute__ ( (weak));
+
+/*+ 
+ * RCN-211
+ * Called when a fastclock date message is received.
+ *
+ *  Inputs:
+ *      DayOfMonth  - 1..31.
+ *      Month       - 1..12  1=January ... 12=December.
+ *      Year        - 0-4095.
+ *
+ *  Returns:
+ *      None
+ */
+extern void notifyFastClockDate( uint8_t  DayOfMonth, uint8_t Month, uint16_t Year) __attribute__ ( (weak));
+
+/*+ 
+ * RCN-211
+ * Called when a system time message is received.
+ *
+ *  Inputs:
+ *      MillisSinceStartup  - milli seconds since system start. Wraps to zero approx. every 65 seconds.
+ *
+ *  Returns:
+ *      None
+ *
+ */
+extern void notifySystemTime( uint16_t MillisSinceStartup) __attribute__ ( (weak));
+
 // Deprecated, only for backward compatibility with version 1.4.2.
 // Don't use in new designs. These functions may be dropped in future versions
 extern void notifyDccAccState (uint16_t Addr, uint16_t BoardAddr, uint8_t OutputAddr, uint8_t State) __attribute__ ( (weak));

--- a/examples/DCC_FastClock/DCC_FastClock.ino
+++ b/examples/DCC_FastClock/DCC_FastClock.ino
@@ -1,0 +1,116 @@
+#include <Arduino.h>
+#include <NmraDcc.h>
+
+//#include <compat/twi.h>  // I2C
+//#include <U8g2lib.h>
+
+
+#define SW_VERSION 1
+
+NmraDcc  Dcc ;
+
+// U8g2 constructor for display
+//U8G2_SSD1306_128X64_NONAME_1_HW_I2C u8g2(U8G2_R0);  // 0.96 display
+
+uint8_t fastClockHours = 0;
+uint8_t fastClockMinutes = 0;
+uint8_t fastClockWeekDay = 0;
+uint8_t fastClockFactor = 0;
+uint8_t fastClockUpdate = 0;
+uint8_t  fastClockDayOfMonth = 0;
+uint8_t  fastClockMonth = 0;
+uint16_t fastClockYear = 0;
+bool newClock = true;
+
+
+
+
+
+//
+// Is called when a RCN-211 Time packet is received
+//
+void notifyFastClockTime( uint8_t day, uint8_t hour, uint8_t minute, uint8_t factor, bool update)
+{
+      fastClockWeekDay = day;
+      fastClockHours = hour;
+      fastClockMinutes = minute;
+      fastClockFactor = factor;
+      fastClockUpdate = update;
+
+      // Signal that a new value has arrived
+      newClock = true;
+}
+
+void notifyFastClockDate( uint8_t dayOfMonth, uint8_t month, uint16_t year)
+{
+      fastClockDayOfMonth = dayOfMonth;
+      fastClockMonth = month;
+      fastClockYear = year;
+
+      // Signal that a new value has arrived
+      newClock = true;
+}
+
+void notifySystemTime( uint16_t millisSinceSystemStart)
+{
+  // Don't know what to do with this.
+}
+
+
+
+
+void setup() {
+  // put your setup code here, to run once:
+
+
+  // Setup which External Interrupt on Pin 2 and enable the Pull-Up (saves us from adding external 10k)
+  Dcc.pin(0, 2, 1);
+
+  // Call the main DCC Init function to enable the DCC Receiver
+  Dcc.initAccessoryDecoder( MAN_ID_DIY, SW_VERSION, CV29_ACCESSORY_DECODER /* | CV29_OUTPUT_ADDRESS_MODE*/, 0 );
+
+  // Startup U8g2 display
+  //u8g2.begin();
+
+}
+
+void loop() {
+ // MUST call the NmraDcc.process() method frequently from the Arduino loop() function for correct library operation
+  Dcc.process();
+
+  if ( newClock) {
+
+    char timemsg[12];
+    char* daymsg = NULL;
+
+    if ( fastClockFactor == 0) {
+      sprintf( timemsg, "%s", "Paused");
+    }
+    else {
+      sprintf( timemsg, "%2d:%02d", fastClockHours, fastClockMinutes);
+      switch ( fastClockWeekDay) {
+        case 0: daymsg = "Monday"; break;
+        case 1: daymsg = "Tuesday"; break;
+        case 2: daymsg = "Wednesday"; break;
+        case 3: daymsg = "Thursday"; break;
+        case 4: daymsg = "Friday"; break;
+        case 5: daymsg = "Saturday"; break;
+        case 6: daymsg = "Sunday"; break;
+        default: daymsg = "?"; break;
+      }
+    }
+      
+    //u8g2.firstPage();
+    //do {
+    //    /* all graphics commands have to appear within the loop body. */    
+    //
+    //  u8g2.setFont(u8g2_font_t0_22_tr);
+    //  if ( daymsg != NULL) {
+    //    u8g2.drawStr( 10, 25, daymsg);
+    //  }
+    //  u8g2.drawStr( 10, 63, timemsg);
+    //} while ( u8g2.nextPage() );
+
+    newClock = false;
+  }
+}


### PR DESCRIPTION
Added support for a subset of RCN-211 features:
- fastclock day of week and time
- date
- systemTime

It is not known how many command stations that can actually send these messages yet. 
My RocoZ21 only sends out the fastclock day of week and time, not the date and system time. Tests done are therefore limited to the actual fastclock.

Simple example of making a clock is included.